### PR TITLE
Disable automatic help display on command failure

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -16,6 +16,7 @@ var infoCmd = &cobra.Command{
 	Long:  `Show detailed information about a specific task.`,
 	Args:  cobra.ExactArgs(1),
 	RunE:  runInfoCommand,
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -25,6 +25,7 @@ var initCmd = &cobra.Command{
 	Short: "Initialize basic tasks.json file",
 	Long:  `Initialize a basic tasks.json file with template support.`,
 	RunE:  runInitCommand,
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -20,6 +20,7 @@ var listCmd = &cobra.Command{
 	Short: "List available tasks",
 	Long:  `List all available tasks from the tasks.json file.`,
 	RunE:  runListCommand,
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ var rootCmd = &cobra.Command{
 	Short: "Execute VS Code tasks from command line",
 	Long: `tasks-json-cli is a CLI tool that executes tasks defined in VS Code's tasks.json configuration files.
 It allows you to run VS Code tasks directly from the command line without needing the editor.`,
+	SilenceUsage: true,
 }
 
 func Execute() {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -23,6 +23,7 @@ var runCommand = &cobra.Command{
 	Long:  `Execute a task defined in the tasks.json file.`,
 	Args:  cobra.ExactArgs(1),
 	RunE:  executeRunCommand,
+	SilenceUsage: true,
 }
 
 func executeRunCommand(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Summary
- Add `SilenceUsage: true` to all cobra commands (root, run, list, init, info)
- Prevents automatic help display when commands fail with errors
- Provides cleaner error output by showing only error messages

## Test plan
- [x] Run tests to ensure functionality remains intact: `go test -v ./...`
- [x] Run linter to verify code quality: `golangci-lint run`
- [x] Verify all commands still work correctly but without automatic help on errors

🤖 Generated with [Claude Code](https://claude.ai/code)